### PR TITLE
Add Azure OpenAI with managed identity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 ANTHROPIC_API_KEY="your-anthropic-api-key" # Needed if proxying *to* Anthropic
 OPENAI_API_KEY="sk-..."
 GEMINI_API_KEY="your-google-ai-studio-key"
+# Azure OpenAI (optional)
+# AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
+# AZURE_OPENAI_API_KEY="your-azure-api-key"  # leave blank to use Managed Identity
+# AZURE_API_VERSION="2023-07-01-preview"
+# AZURE_DEPLOYMENT_NAME="your-deployment"
 
 # Optional: Provider Preference and Model Mapping
 # Controls which provider (google or openai) is preferred for mapping haiku/sonnet.
@@ -18,4 +23,9 @@ PREFERRED_PROVIDER="openai"
 # Example Google mapping:
 # PREFERRED_PROVIDER="google"
 # BIG_MODEL="gemini-2.5-pro-preview-03-25"
-# SMALL_MODEL="gemini-2.0-flash" 
+# SMALL_MODEL="gemini-2.0-flash"
+
+# Example Azure mapping:
+# PREFERRED_PROVIDER="azure"
+# BIG_MODEL="my-azure-deployment-big"
+# SMALL_MODEL="my-azure-deployment-small"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A proxy server that lets you use Anthropic clients with Gemini or OpenAI models 
    *   `ANTHROPIC_API_KEY`: (Optional) Needed only if proxying *to* Anthropic models.
    *   `OPENAI_API_KEY`: Your OpenAI API key (Required if using the default OpenAI preference or as fallback).
    *   `GEMINI_API_KEY`: Your Google AI Studio (Gemini) API key (Required if PREFERRED_PROVIDER=google).
+   *   `AZURE_OPENAI_ENDPOINT` / `AZURE_OPENAI_API_KEY`: Azure endpoint and API key (leave key empty to use Managed Identity).
    *   `PREFERRED_PROVIDER` (Optional): Set to `openai` (default) or `google`. This determines the primary backend for mapping `haiku`/`sonnet`.
    *   `BIG_MODEL` (Optional): The model to map `sonnet` requests to. Defaults to `gpt-4.1` (if `PREFERRED_PROVIDER=openai`) or `gemini-2.5-pro-preview-03-25`.
    *   `SMALL_MODEL` (Optional): The model to map `haiku` requests to. Defaults to `gpt-4.1-mini` (if `PREFERRED_PROVIDER=openai`) or `gemini-2.0-flash`.
@@ -139,6 +140,15 @@ GEMINI_API_KEY="your-google-key"
 PREFERRED_PROVIDER="openai"
 BIG_MODEL="gpt-4o" # Example specific model
 SMALL_MODEL="gpt-4o-mini" # Example specific model
+```
+
+**Example 4: Azure with Managed Identity**
+```dotenv
+AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
+# AZURE_OPENAI_API_KEY="" # Omit to use Managed Identity
+PREFERRED_PROVIDER="azure"
+BIG_MODEL="my-azure-deployment-big"
+SMALL_MODEL="my-azure-deployment-small"
 ```
 
 ## How It Works 🧩

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,6 @@ dependencies = [
     "pydantic>=2.0.0",
     "litellm>=1.40.14",
     "python-dotenv>=1.0.0",
+    "azure-identity>=1.16.0",
 ]
 

--- a/server.py
+++ b/server.py
@@ -81,6 +81,11 @@ app = FastAPI()
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
+# Azure OpenAI optional configuration
+AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT")
+AZURE_OPENAI_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY")
+AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION")
+AZURE_DEPLOYMENT_NAME = os.environ.get("AZURE_DEPLOYMENT_NAME")
 
 # Get preferred provider (default to openai)
 PREFERRED_PROVIDER = os.environ.get("PREFERRED_PROVIDER", "openai").lower()
@@ -111,6 +116,9 @@ GEMINI_MODELS = [
     "gemini-2.5-pro-preview-03-25",
     "gemini-2.0-flash"
 ]
+
+# Azure deployment names can vary, so this is just a placeholder list
+AZURE_MODELS = []
 
 # Helper function to clean schema for Gemini
 def clean_gemini_schema(schema: Any) -> Any:
@@ -210,6 +218,9 @@ class MessagesRequest(BaseModel):
             if PREFERRED_PROVIDER == "google" and SMALL_MODEL in GEMINI_MODELS:
                 new_model = f"gemini/{SMALL_MODEL}"
                 mapped = True
+            elif PREFERRED_PROVIDER == "azure" and SMALL_MODEL:
+                new_model = f"azure/{SMALL_MODEL}"
+                mapped = True
             else:
                 new_model = f"openai/{SMALL_MODEL}"
                 mapped = True
@@ -218,6 +229,9 @@ class MessagesRequest(BaseModel):
         elif 'sonnet' in clean_v.lower():
             if PREFERRED_PROVIDER == "google" and BIG_MODEL in GEMINI_MODELS:
                 new_model = f"gemini/{BIG_MODEL}"
+                mapped = True
+            elif PREFERRED_PROVIDER == "azure" and BIG_MODEL:
+                new_model = f"azure/{BIG_MODEL}"
                 mapped = True
             else:
                 new_model = f"openai/{BIG_MODEL}"
@@ -231,6 +245,9 @@ class MessagesRequest(BaseModel):
             elif clean_v in OPENAI_MODELS and not v.startswith('openai/'):
                 new_model = f"openai/{clean_v}"
                 mapped = True # Technically mapped to add prefix
+            elif clean_v in AZURE_MODELS and not v.startswith('azure/'):
+                new_model = f"azure/{clean_v}"
+                mapped = True
         # --- Mapping Logic --- END ---
 
         if mapped:
@@ -283,6 +300,9 @@ class TokenCountRequest(BaseModel):
             if PREFERRED_PROVIDER == "google" and SMALL_MODEL in GEMINI_MODELS:
                 new_model = f"gemini/{SMALL_MODEL}"
                 mapped = True
+            elif PREFERRED_PROVIDER == "azure" and SMALL_MODEL:
+                new_model = f"azure/{SMALL_MODEL}"
+                mapped = True
             else:
                 new_model = f"openai/{SMALL_MODEL}"
                 mapped = True
@@ -291,6 +311,9 @@ class TokenCountRequest(BaseModel):
         elif 'sonnet' in clean_v.lower():
             if PREFERRED_PROVIDER == "google" and BIG_MODEL in GEMINI_MODELS:
                 new_model = f"gemini/{BIG_MODEL}"
+                mapped = True
+            elif PREFERRED_PROVIDER == "azure" and BIG_MODEL:
+                new_model = f"azure/{BIG_MODEL}"
                 mapped = True
             else:
                 new_model = f"openai/{BIG_MODEL}"
@@ -304,6 +327,9 @@ class TokenCountRequest(BaseModel):
             elif clean_v in OPENAI_MODELS and not v.startswith('openai/'):
                 new_model = f"openai/{clean_v}"
                 mapped = True # Technically mapped to add prefix
+            elif clean_v in AZURE_MODELS and not v.startswith('azure/'):
+                new_model = f"azure/{clean_v}"
+                mapped = True
         # --- Mapping Logic --- END ---
 
         if mapped:
@@ -555,7 +581,28 @@ def convert_anthropic_to_litellm(anthropic_request: MessagesRequest) -> Dict[str
     
     if anthropic_request.top_k:
         litellm_request["top_k"] = anthropic_request.top_k
-    
+
+    # Azure OpenAI configuration if model starts with azure/
+    if anthropic_request.model.startswith("azure/"):
+        litellm_request["model"] = anthropic_request.model[len("azure/") :]
+        if AZURE_OPENAI_API_KEY:
+            litellm_request["api_key"] = AZURE_OPENAI_API_KEY
+        else:
+            try:
+                from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+
+                token_provider = get_bearer_token_provider(
+                    DefaultAzureCredential(),
+                    "https://cognitiveservices.azure.com/.default",
+                )
+                litellm_request["azure_ad_token_provider"] = token_provider
+            except Exception as e:
+                logger.error(f"Azure credential error: {e}")
+        if AZURE_OPENAI_ENDPOINT:
+            litellm_request["api_base"] = AZURE_OPENAI_ENDPOINT
+        if AZURE_API_VERSION:
+            litellm_request["api_version"] = AZURE_API_VERSION
+
     # Convert tools to OpenAI format
     if anthropic_request.tools:
         openai_tools = []

--- a/tests.py
+++ b/tests.py
@@ -147,6 +147,15 @@ TEST_SCENARIOS = {
         "tools": [calculator_tool],
         "tool_choice": {"type": "auto"}
     },
+
+    # Azure simple test if configured
+    "azure_simple": {
+        "model": f"azure/{os.environ.get('AZURE_DEPLOYMENT_NAME','')}",
+        "max_tokens": 100,
+        "messages": [
+            {"role": "user", "content": "Hello from Azure?"}
+        ]
+    } if os.environ.get("AZURE_OPENAI_ENDPOINT") else None,
     
     # Content blocks
     "content_blocks": {
@@ -640,6 +649,8 @@ async def run_tests(args):
     if not args.streaming_only:
         print("\n\n=========== RUNNING NON-STREAMING TESTS ===========\n")
         for test_name, test_data in TEST_SCENARIOS.items():
+            if not test_data:
+                continue
             # Skip streaming tests
             if test_data.get("stream"):
                 continue
@@ -661,6 +672,8 @@ async def run_tests(args):
     if not args.no_streaming:
         print("\n\n=========== RUNNING STREAMING TESTS ===========\n")
         for test_name, test_data in TEST_SCENARIOS.items():
+            if not test_data:
+                continue
             # Only select streaming tests, or force streaming
             if not test_data.get("stream") and not test_name.endswith("_stream"):
                 continue


### PR DESCRIPTION
## Summary
- support Azure OpenAI via env vars
- allow managed identity token if no API key
- document Azure options in README and `.env.example`
- add optional Azure scenario to tests

## Testing
- `python tests.py --simple` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687bb95ddc608329aae376091ae5502e